### PR TITLE
Upgrade to use separate proptypes library for react 16

### DIFF
--- a/lib/Avatar.js
+++ b/lib/Avatar.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {View, Image, Text} from "react-native";
 import Icon from './Icon';
 import { getColor } from './helpers';

--- a/lib/Button.js
+++ b/lib/Button.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {ActivityIndicator, View, Text, TouchableNativeFeedback, Platform} from "react-native";
 import Ripple from './polyfill/Ripple';
 import { TYPO, PRIMARY, THEME_NAME, PRIMARY_COLORS } from './config';

--- a/lib/Card/Actions.js
+++ b/lib/Card/Actions.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {StyleSheet, View} from "react-native";
 
 export default class Actions extends Component {

--- a/lib/Card/Body.js
+++ b/lib/Card/Body.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {StyleSheet, View} from "react-native";
 
 export default class Body extends Component {

--- a/lib/Card/Media.js
+++ b/lib/Card/Media.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {StyleSheet, Image, View} from "react-native";
 
 export default class Media extends Component {

--- a/lib/Card/index.js
+++ b/lib/Card/index.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {View, TouchableNativeFeedback} from "react-native";
 import Ripple from '../polyfill/Ripple';
 import { getColor, isCompatible } from '../helpers';

--- a/lib/Checkbox.js
+++ b/lib/Checkbox.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {StyleSheet, Text, View, TouchableHighlight} from "react-native";
 import { TYPO, PRIMARY, COLOR, PRIMARY_COLORS, THEME_NAME } from './config';
 import Icon from './Icon';

--- a/lib/CheckboxGroup.js
+++ b/lib/CheckboxGroup.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {View} from "react-native";
 import Checkbox from './Checkbox';
 import { THEME_NAME, PRIMARY, PRIMARY_COLORS } from './config';

--- a/lib/Divider.js
+++ b/lib/Divider.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {View} from "react-native";
 import { THEME_NAME } from './config';
 

--- a/lib/Drawer/Header.js
+++ b/lib/Drawer/Header.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {View, Image} from "react-native";
 
 export default class Header extends Component {

--- a/lib/Drawer/Section.js
+++ b/lib/Drawer/Section.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {View, Text, TouchableNativeFeedback} from "react-native";
 import Icon from '../Icon';
 import Ripple from '../polyfill/Ripple';

--- a/lib/Drawer/index.js
+++ b/lib/Drawer/index.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {ScrollView} from "react-native";
 import { THEME_NAME, PRIMARY_COLORS } from '../config';
 import { getColor } from '../helpers';

--- a/lib/Icon.js
+++ b/lib/Icon.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {View} from "react-native";
 import { getColor } from './helpers';
 import VectorIconComponent from './VectorIconComponent';

--- a/lib/IconToggle.js
+++ b/lib/IconToggle.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {Text, View, Animated} from "react-native";
 import { getColor } from './helpers';
 

--- a/lib/List.js
+++ b/lib/List.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {StyleSheet, View, Text, TouchableWithoutFeedback} from "react-native";
 import { TYPO } from './config';
 

--- a/lib/RadioButton.js
+++ b/lib/RadioButton.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {StyleSheet, Text, View, TouchableHighlight} from "react-native";
 import Icon from './Icon';
 import IconToggle from './IconToggle';

--- a/lib/RadioButtonGroup.js
+++ b/lib/RadioButtonGroup.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {View} from "react-native";
 import RadioButton from './RadioButton';
 import { PRIMARY, PRIMARY_COLORS, THEME_NAME } from './config';

--- a/lib/Ripple.js
+++ b/lib/Ripple.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {View, Text, TouchableNativeFeedback} from "react-native";
 import { default as PolyfillRipple } from './polyfill/Ripple';
 import { isCompatible } from './helpers';
@@ -49,4 +50,3 @@ export default class Ripple extends Component {
     }
 
 }
-

--- a/lib/Subheader.js
+++ b/lib/Subheader.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {StyleSheet, View, Text} from "react-native";
 import { TYPO, THEME_NAME } from './config';
 import { getColor } from './helpers';

--- a/lib/Toolbar.js
+++ b/lib/Toolbar.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {View, Text} from "react-native";
 import { TYPO, PRIMARY, THEME_NAME, PRIMARY_COLORS } from './config';
 import { getColor } from './helpers';

--- a/lib/polyfill/Ripple.js
+++ b/lib/polyfill/Ripple.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, {Component} from "react";
+import PropTypes from 'prop-types';
 import {View, Animated, TouchableOpacity, Platform} from "react-native";
 
 import elevationPolyfill from './Elevation';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/react-native-material-design/react-native-material-design",
   "dependencies": {
     "react-native-material-design-styles": "git+https://github.com/react-native-material-design/react-native-material-design-styles.git",
-    "react-native-vector-icons": "^2.0.1"
+    "react-native-vector-icons": "^4.4.2"
   },
   "devDependencies": {
     "babel-eslint": "^4.1.6",


### PR DESCRIPTION
In react 16 and up, **React.Proptypes** no longer exists. Instead we must use the new, separate proptypes library:    
https://github.com/facebook/prop-types

react-native version 0.49 uses react 16 https://github.com/facebook/react-native/blob/v0.49.0/package.json#L135

So react-native-material-design must be updated or it will be remain incompatible with newer versions of react-native. 

I have removed any references to the React.proptypes while also updating the dependency of **react-native-vector-icons**

That dependency has been updated to use the correct proptypes so we only have to update to the newest and it is fine. 

